### PR TITLE
fix: linkify hashtags from message text, not only WP tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-04-13
+
+### Fixed
+- Hashtags written directly in the post template (outside the `{hashtags}` placeholder) are now linkified on Bluesky by parsing the final post text for tag facets and merging them with WordPress-tag and Yoast cashtag facets
+
 ## [1.7.1] - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The plugin automatically converts WordPress post tags into Bluesky hashtags. Whe
 
 The hashtags are generated from the tag slugs, ensuring they are properly formatted for Bluesky (lowercase, with hyphens instead of spaces).
 
+You can also add fixed hashtags in the template itself (for example `{title} {hashtags} #brand`). Any hashtag that appears in the final text receives a Bluesky tag facet, not only tags from `{hashtags}`.
+
 ## Yoast SEO Integration
 
 The plugin includes comprehensive integration with Yoast SEO to enhance your Bluesky posts with optimized metadata. When Yoast SEO is active and the integration is enabled, the plugin automatically uses Yoast SEO's social media and SEO metadata (titles, descriptions, images, URLs) instead of default WordPress content. For sites using Yoast SEO News, stock tickers are automatically converted to clickable cashtags on Bluesky. See the [Yoast SEO Integration documentation](yoast.md) for complete details on this feature.
@@ -109,6 +111,9 @@ This plugin is licensed under the GPL v2 or later.
 Developed by [Alessio Bragadini](https://techartconsulting.it/alessio-bragadini/)
 
 ## Changelog
+
+### 1.7.2
+- Fixed hashtags in the post template (outside `{hashtags}`) not being clickable on Bluesky; facets are now derived from the full message text as well as WordPress tags
 
 ### 1.7.1
 - Fixed featured image download failing on servers with self-signed or expired SSL certificates

--- a/includes/class-wp-bsky-autoposter-api.php
+++ b/includes/class-wp-bsky-autoposter-api.php
@@ -526,6 +526,127 @@ class WP_BSky_AutoPoster_API {
     }
 
     /**
+     * Parse hashtag facets from post text (e.g. template literals outside {hashtags}).
+     *
+     * Detection follows the Bluesky rich-text reference (boundaries, trailing punctuation,
+     * UTF-8 byte offsets). @see https://docs.bsky.app/docs/advanced-guides/post-richtext
+     *
+     * @since    1.7.2
+     * @param    string $message UTF-8 post text.
+     * @return   array  Facet structures with byteStart/byteEnd into $message.
+     */
+    private function parse_hashtag_facets_from_message($message) {
+        if ($message === '' || $message === null) {
+            return array();
+        }
+
+        $facets = array();
+        if (!preg_match_all('/(?:^|\s)(#[^\d\s]\S*)/u', $message, $regexp_matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+            return $facets;
+        }
+
+        foreach ($regexp_matches as $match) {
+            if (empty($match[1]) || !isset($match[1][0])) {
+                continue;
+            }
+            $raw = $match[1][0];
+            $byte_pos = (int) $match[1][1];
+            if ($raw === '') {
+                continue;
+            }
+
+            $tag = preg_replace('/\p{P}+$/u', '', $raw);
+            if ($tag === '' || strpos($tag, '#') !== 0) {
+                continue;
+            }
+            if (strlen($tag) > 66) {
+                continue;
+            }
+
+            $byte_end = $byte_pos + strlen($tag);
+            if ($byte_end > strlen($message)) {
+                continue;
+            }
+
+            $slug = substr($tag, 1);
+            if ($slug === '') {
+                continue;
+            }
+
+            $facets[] = array(
+                'index' => array(
+                    'byteStart' => $byte_pos,
+                    'byteEnd' => $byte_end,
+                ),
+                'features' => array(
+                    array(
+                        '$type' => 'app.bsky.richtext.facet#tag',
+                        'tag' => strtolower($slug),
+                    ),
+                ),
+            );
+        }
+
+        return $facets;
+    }
+
+    /**
+     * Sort facets by start offset and drop overlaps and exact duplicates.
+     *
+     * Bluesky recommends non-overlapping facets; keep the first facet in sort order
+     * (earlier byteStart; longer span when start ties).
+     *
+     * @since    1.7.2
+     * @param    array $facets Facet structures with index.byteStart / index.byteEnd.
+     * @return   array Merged facets.
+     */
+    private function merge_facets_remove_overlaps($facets) {
+        if (empty($facets)) {
+            return array();
+        }
+
+        usort(
+            $facets,
+            function ($a, $b) {
+                $s1 = $a['index']['byteStart'];
+                $s2 = $b['index']['byteStart'];
+                if ($s1 !== $s2) {
+                    return $s1 <=> $s2;
+                }
+                return $b['index']['byteEnd'] <=> $a['index']['byteEnd'];
+            }
+        );
+
+        $merged = array();
+        foreach ($facets as $f) {
+            if (empty($f['index']) || !isset($f['index']['byteStart'], $f['index']['byteEnd'])) {
+                continue;
+            }
+            $s = (int) $f['index']['byteStart'];
+            $e = (int) $f['index']['byteEnd'];
+            if ($e <= $s) {
+                continue;
+            }
+            if (empty($merged)) {
+                $merged[] = $f;
+                continue;
+            }
+            $prev = $merged[count($merged) - 1];
+            $ps = (int) $prev['index']['byteStart'];
+            $pe = (int) $prev['index']['byteEnd'];
+            if ($s === $ps && $e === $pe) {
+                continue;
+            }
+            if ($s >= $pe) {
+                $merged[] = $f;
+                continue;
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
      * Post to Bluesky.
      *
      * @since    1.0.0
@@ -662,7 +783,11 @@ class WP_BSky_AutoPoster_API {
                 }
             }
         }
-        
+
+        $message_hashtag_facets = $this->parse_hashtag_facets_from_message($message);
+        $facets = array_merge($facets, $message_hashtag_facets);
+        $facets = $this->merge_facets_remove_overlaps($facets);
+
         if (!empty($facets)) {
             $post_data['record']['facets'] = $facets;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: abragad
 Tags: bluesky, social media, automation, at protocol
 Requires at least: 5.0
 Tested up to: 6.4
-Stable tag: 1.7.1
+Stable tag: 1.7.2
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -127,6 +127,9 @@ If you're using Yoast SEO News and have stock tickers configured (e.g., "NASDAQ:
 
 == Changelog ==
 
+= 1.7.2 =
+* Fixed hashtags added directly in the post template (not only via the {hashtags} placeholder) not being clickable on Bluesky
+
 = 1.7.1 =
 * Fixed featured image download failing on servers with self-signed or expired SSL certificates
 
@@ -214,6 +217,9 @@ If you're using Yoast SEO News and have stock tickers configured (e.g., "NASDAQ:
 * Scheduled post support
 
 == Upgrade Notice ==
+
+= 1.7.2 =
+Template hashtags outside the {hashtags} placeholder are now clickable on Bluesky.
 
 = 1.7.1 =
 Fixed featured image download on servers with self-signed or expired SSL certificates.

--- a/tests/test-hashtag-facets-message.php
+++ b/tests/test-hashtag-facets-message.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * CLI tests for hashtag facets parsed from post text (no full WordPress load).
+ *
+ * @package WP_BSky_AutoPoster
+ */
+
+if ( ! function_exists( 'get_option' ) ) {
+	/**
+	 * Minimal stub for CLI tests.
+	 *
+	 * @param string $option  Option name.
+	 * @param mixed  $default Default value.
+	 * @return mixed
+	 */
+	function get_option( $option, $default = false ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- CLI stub only.
+		return $default;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-wp-bsky-autoposter-api.php';
+
+$reflection = new ReflectionClass( 'WP_Bsky_AutoPoster_API' );
+$parse_m    = $reflection->getMethod( 'parse_hashtag_facets_from_message' );
+$parse_m->setAccessible( true );
+$merge_m    = $reflection->getMethod( 'merge_facets_remove_overlaps' );
+$merge_m->setAccessible( true );
+
+$api = new WP_Bsky_AutoPoster_API();
+$failed = 0;
+
+/**
+ * Record assertion result.
+ *
+ * @param bool   $ok    Whether the assertion passed.
+ * @param string $label Description.
+ */
+$assert = function ( $ok, $label ) use ( &$failed ) {
+	if ( ! $ok ) {
+		echo 'FAIL: ' . $label . "\n";
+		$failed++;
+	} else {
+		echo 'PASS: ' . $label . "\n";
+	}
+};
+
+// Template-style message: literal #superyacht (not necessarily a WP tag).
+$msg    = 'Giangrasso G24 Classic #giangrasso-group #palma-superyacht #superyacht';
+$want   = strpos( $msg, '#superyacht' );
+$facets = $parse_m->invoke( $api, $msg );
+$found  = false;
+foreach ( $facets as $f ) {
+	if ( isset( $f['features'][0]['tag'] ) && 'superyacht' === $f['features'][0]['tag'] && $want === $f['index']['byteStart'] ) {
+		$found = true;
+		break;
+	}
+}
+$assert( $found, 'Parse finds template literal #superyacht at correct byte offset' );
+
+// UTF-8 prefix before ASCII hashtags.
+$msg_utf8 = "Caffè giorno #foo #superyacht";
+$pos_foo  = strpos( $msg_utf8, '#foo' );
+$facets_u = $parse_m->invoke( $api, $msg_utf8 );
+$foo_ok   = false;
+foreach ( $facets_u as $f ) {
+	if ( isset( $f['features'][0]['tag'] ) && 'foo' === $f['features'][0]['tag'] && $pos_foo === $f['index']['byteStart'] ) {
+		$foo_ok = true;
+		break;
+	}
+}
+$assert( $foo_ok, 'UTF-8 prefix: #foo byte offset matches strpos' );
+
+// Merge drops exact duplicates.
+$dup_a = array(
+	array(
+		'index'    => array(
+			'byteStart' => 10,
+			'byteEnd'   => 22,
+		),
+		'features' => array(
+			array(
+				'$type' => 'app.bsky.richtext.facet#tag',
+				'tag'   => 'superyacht',
+			),
+		),
+	),
+	array(
+		'index'    => array(
+			'byteStart' => 10,
+			'byteEnd'   => 22,
+		),
+		'features' => array(
+			array(
+				'$type' => 'app.bsky.richtext.facet#tag',
+				'tag'   => 'superyacht',
+			),
+		),
+	),
+);
+$merged_dup = $merge_m->invoke( $api, $dup_a );
+$assert( 1 === count( $merged_dup ), 'Merge drops exact duplicate facets' );
+
+// Overlapping ranges: keep first in sort order (earlier start; longer wins on tie).
+$ov = array(
+	array(
+		'index'    => array(
+			'byteStart' => 5,
+			'byteEnd'   => 12,
+		),
+		'features' => array(
+			array(
+				'$type' => 'app.bsky.richtext.facet#tag',
+				'tag'   => 'b',
+			),
+		),
+	),
+	array(
+		'index'    => array(
+			'byteStart' => 0,
+			'byteEnd'   => 20,
+		),
+		'features' => array(
+			array(
+				'$type' => 'app.bsky.richtext.facet#tag',
+				'tag'   => 'a',
+			),
+		),
+	),
+);
+$merged_ov = $merge_m->invoke( $api, $ov );
+$assert( 1 === count( $merged_ov ), 'Merge keeps one facet when ranges overlap' );
+$assert(
+	0 === $merged_ov[0]['index']['byteStart'] && 20 === $merged_ov[0]['index']['byteEnd'],
+	'Kept overlapping facet is the one sorted first (earlier byteStart)'
+);
+
+exit( $failed > 0 ? 1 : 0 );

--- a/wp-bsky-autoposter.php
+++ b/wp-bsky-autoposter.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP AutoPoster to Bluesky
  * Plugin URI: https://github.com/abragad/wp-bsky-autoposter
  * Description: Automatically posts new WordPress posts to Bluesky with rich link previews.
- * Version: 1.7.1
+ * Version: 1.7.2
  * Author: Alessio Bragadini <alessio@techartconsulting.it>
  * Author URI: https://techartconsulting.it/alessio-bragadini
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('WPINC')) {
 }
 
 // Plugin version
-define('WP_BSKY_AUTOPOSTER_VERSION', '1.7.1');
+define('WP_BSKY_AUTOPOSTER_VERSION', '1.7.2');
 define('WP_BSKY_AUTOPOSTER_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WP_BSKY_AUTOPOSTER_PLUGIN_URL', plugin_dir_url(__FILE__));
 


### PR DESCRIPTION
Parse hashtag facets from final post text (Bluesky-style boundaries and byte offsets) and merge with WP-tag/Yoast facets, dropping overlaps.

Fixes template literals such as "{title} {hashtags} #brand" when the extra tag is not a WordPress post tag.

Refs: https://github.com/abragad/wp-bsky-autoposter/issues/21
Made-with: Cursor